### PR TITLE
Added API variant that expects pattern as RegEx, doesn't modify it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,28 @@ recursive file search with depth [ { dir: 'C:\\Users\\abu8kor\\Documents\\Other 
     file: 'indexx' } ]
 ```
 
+`findFiles()` takes `pattern` as a string or RegEx and converts it into a RegEx with added ^ and $ boundary markers. If you want to provide
+an explicit RegEx object which is used without modification, you can use this variant:
+
+```
+var findFiles = require('file-regex').byRegex;
+
+findFile(__dirname, /^in.*\.js$/, function(err, files) {
+  console.log(files);
+})
+Result:
+['index.js']
+
+```
+
 ### Constructor
 
 **findFiles(path, pattern [, recursive[, depth]], callback)**
 
-*path* - the path in which you want to perform file search  
-*pattern* - regex pattern to search the files  
-*recursive* - if true, then a recursive search is performed for the depth mentioned. *default* is false  
-*depth* - the recursive depth upto which the file shall be searched.  
+*path* - the path in which you want to perform file search
+*pattern* - regex pattern to search the files
+*recursive* - if true, then a recursive search is performed for the depth mentioned. *default* is false
+*depth* - the recursive depth upto which the file shall be searched.
 *callback(err, files)* - if recursive is false, then the files array will contain only the string of filenames, else it will contain an array of Objects which would provide information regarding the directory in which the matched file was found.
 
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function recursiveSearch(cwd, regex, depth) {
     }
 }
 
-function findFile(cwd, pattern, recursive, depth, cb) {
+function findFileByRegex(cwd, regex, recursive, depth, cb) {
 
     if (recursive.constructor == Function) {
         cb = recursive;
@@ -34,8 +34,6 @@ function findFile(cwd, pattern, recursive, depth, cb) {
         cb = depth;
         depth = 100;
     }
-
-    var regex = new RegExp('^' + pattern + "$");
 
     if (recursive) {
         cb(null, recursiveSearch(cwd, regex, depth));
@@ -50,5 +48,14 @@ function findFile(cwd, pattern, recursive, depth, cb) {
         })
     }
 }
+
+function findFile(cwd, pattern, recursive, depth, cb) {
+
+    var regex = new RegExp('^' + pattern + "$");
+
+    findFileByRegex(cwd, regex, recursive, depth, cb);
+}
+
+findFile.byRegex = findFileByRegex;
 
 module.exports = findFile;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-regex",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Find files by using regex",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -2,13 +2,17 @@ var findFiles = require('./index');
 
 
 findFiles(__dirname, "in.*", function(err, files){
-  console.log('no recursion', err, files);
+  console.log('no recursion:', err, files);
  })
 
 findFiles(__dirname, 'in.*', true, function(err, files) {
-  console.log('recursive file search without depth', err, files);
+  console.log('recursive file search without depth:', err, files);
 })
 
 findFiles(__dirname, 'in.*', true, 2, function(err, files) {
-  console.log('recursive file search with depth', err, files);
+  console.log('recursive file search with depth:', err, files);
+})
+
+findFiles.byRegex(__dirname, /^in.*$/, true, 2, function(err, files) {
+  console.log('recursive file search with depth, by regex:', err, files);
 })


### PR DESCRIPTION
The existing findFiles() API takes `pattern` and converts it as a string to a RegEx of the form /^pattern$/.

I'd rather create my own RegEx and have it used by findFiles() unmodified, but I don't want to disturb the current API for existing users.

Test added for new functionality, existing test results unchanged.