### PR TITLE
Global regex patterns test against the full filepath, like glob does.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -76,9 +76,9 @@
         "no-bitwise": 0,
         "no-multi-assign": 0,
         "complexity": [
-            "error",
+            "warn",
             {
-                "max": 5
+                "max": 6
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
     "name": "file-regex",
     "version": "3.0.2",
     "description": "Find files by using regex",
-    "main": "index.js",
+    "main": "dist/index.js",
     "scripts": {
+        "postinstall": "npm run build",
         "_test": "npm run build && mocha --require babel-core/register --require babel-polyfill test/**/*.test.js",
         "_test:exit": "npm run _test -- --exit",
         "test": "export NODE_ENV=test && npm run _test:exit",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "description": "Find files by using regex",
     "main": "dist/index.js",
     "scripts": {
-        "postinstall": "npm run build",
         "_test": "npm run build && mocha --require babel-core/register --require babel-polyfill test/**/*.test.js",
         "_test:exit": "npm run _test -- --exit",
         "test": "export NODE_ENV=test && npm run _test:exit",

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,23 @@ const fs_stat = promisify(fs.stat);
 
 async function search(dir, regex, depth, result = [], concurrency) {
     async function fileAnalyzer(file) {
-        const stat = await fs_stat(path.join(dir, file));
-        if (stat.isFile() && regex.test(file)) {
-            result.push({ dir, file });
-        } else if (stat.isDirectory() && depth > 0) {
-            await search(path.join(dir, file), regex, depth - 1, result, concurrency);
+        const statPath = path.join(dir, file);
+        const stat = await fs_stat(statPath);
+
+        if (!regex.global) {
+            if (stat.isFile() && regex.test(file)) {
+                result.push({ dir, file });
+            } else if (stat.isDirectory() && depth > 0) {
+                await search(path.join(dir, file), regex, depth - 1, result, concurrency);
+            }
+        } else { // scan the entire path for the regex if the pattern uses a //g
+            if (regex.test(statPath)) {
+                result.push({ dir, file });
+            }
+
+            if (stat.isDirectory() && depth > 0) {
+                await search(path.join(dir, file), regex, depth - 1, result, concurrency);
+            }
         }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,15 +15,16 @@ async function search(dir, regex, depth, result = [], concurrency) {
             if (stat.isFile() && regex.test(file)) {
                 result.push({ dir, file });
             } else if (stat.isDirectory() && depth > 0) {
-                await search(path.join(dir, file), regex, depth - 1, result, concurrency);
+                await search(statPath, regex, depth - 1, result, concurrency);
             }
         } else { // scan the entire path for the regex if the pattern uses a //g
             if (regex.test(statPath)) {
                 result.push({ dir, file });
+                regex.lastIndex = 0; // reset the last index for global searches
             }
 
             if (stat.isDirectory() && depth > 0) {
-                await search(path.join(dir, file), regex, depth - 1, result, concurrency);
+                await search(statPath, regex, depth - 1, result, concurrency);
             }
         }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -14,18 +14,16 @@ async function search(dir, regex, depth, result = [], concurrency) {
         if (!regex.global) {
             if (stat.isFile() && regex.test(file)) {
                 result.push({ dir, file });
-            } else if (stat.isDirectory() && depth > 0) {
-                await search(statPath, regex, depth - 1, result, concurrency);
             }
         } else { // scan the entire path for the regex if the pattern uses a //g
             if (regex.test(statPath)) {
                 result.push({ dir, file });
                 regex.lastIndex = 0; // reset the last index for global searches
             }
+        }
 
-            if (stat.isDirectory() && depth > 0) {
-                await search(statPath, regex, depth - 1, result, concurrency);
-            }
+        if (stat.isDirectory() && depth > 0) {
+            await search(statPath, regex, depth - 1, result, concurrency);
         }
     }
 

--- a/test/findFiles.test.js
+++ b/test/findFiles.test.js
@@ -48,6 +48,22 @@ describe('#functionality FindFiles', () => {
         result.forEach(r => expect(pattern.test(r.file)).to.be.true);
     });
 
+    it('should find all the files with filepaths matching the given global regex', async () => {
+        const pattern = /\.js$/g;
+        const patternNoG = /\.js$/; // use later to avoid having to reset pattern.lastIndex in forEach
+        const result = await FindFiles(testFolder, pattern);
+        expect(result.length).to.be.eql(2);
+
+        result.forEach(r => expect(r.dir).to.be.eql(testFolder));
+        result.forEach(r => expect(patternNoG.test(r.file)).to.be.true);
+    });
+
+    it('should find every js/ts file with partial dirname in its path', async () => {
+        const pattern = /\/dir4\/.*\.[jt]s$/g;
+        const result = await FindFiles(testFolder, pattern, 32);
+        expect(result.length).to.be.eql(3); // 10 js files
+    });
+
     it('should find all the files matching the given pattern string', async () => {
         const pattern = '\.js$';
         const result = await FindFiles(testFolder, pattern);
@@ -63,8 +79,20 @@ describe('#functionality FindFiles', () => {
         expect(result.length).to.be.eql(4);
     });
 
+    it('should full-path search files only till the given depth', async () => {
+        const pattern = /\.ts$/;
+        const result = await FindFiles(testFolder, pattern, 2);
+        expect(result.length).to.be.eql(4);
+    });
+
     it('should not perform any search if the given depth = -1', async () => {
         const pattern = /\.js$/;
+        const result = await FindFiles(testFolder, pattern, -1);
+        expect(result.length).to.be.eql(0);
+    });
+
+    it('should not perform any full-path search if the given depth = -1', async () => {
+        const pattern = /\.js$/g;
         const result = await FindFiles(testFolder, pattern, -1);
         expect(result.length).to.be.eql(0);
     });


### PR DESCRIPTION
Global regex patterns (//g) test against the full filepath, like glob does.

NPM "main" points to dist/index.js. NPM postinstall runs a build to create /dist.